### PR TITLE
Add a cache buster for static assets

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,10 +6,10 @@
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+  <link rel="stylesheet" href="{{ "/css/main.css?" | prepend: site.baseurl }}{% bust_cache %}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
-  <script src="{{ "/js/subscribe.js" | prepend: site.baseurl }}"></script>
+  <script src="{{ "/js/subscribe.js?" | prepend: site.baseurl }}{% bust_cache %}"></script>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/_plugins/cachebuster.rb
+++ b/_plugins/cachebuster.rb
@@ -1,0 +1,13 @@
+require 'digest/sha1'
+
+# https://gist.github.com/daneden/7027258
+module Jekyll
+  class CacheBuster < Liquid::Tag
+
+    def render(context)
+      "#{Digest::SHA1.hexdigest(Time.now.to_s)}"
+    end
+  end
+end
+
+Liquid::Template.register_tag('bust_cache', Jekyll::CacheBuster)


### PR DESCRIPTION
This fixes #16 by adding a cache buster plugin and the proper syntax to
the header. This is applied to both the JavaScript and the CSS. If the
HTML is being cached, a change will need to be made on to the nginx
configuration.