### PR TITLE
Fix broken links on the workshop page

### DIFF
--- a/_src/pages/workshops.html
+++ b/_src/pages/workshops.html
@@ -22,11 +22,17 @@ slug: workshops
         <div class="section__content no-margin">
           <ul class="card-list text-left">
             {% for workshop in site.workshops %}
-              <li>
-                <a class="card" href="{{ workshop.url }}">
+              {% if workshop.url !== 'none' %}
+                <li>
+                  <a class="card" href="{{ workshop.url }}">
+                    <span class="card__date">{{ workshop.date }}</span> {{ workshop.name }}
+                  </a>
+                </li>
+              {% else %}
+                <li class="card">
                   <span class="card__date">{{ workshop.date }}</span> {{ workshop.name }}
-                </a>
-              </li>
+                </li>
+              {% endif %}
             {% endfor %}
           </ul>
         </div>


### PR DESCRIPTION
If a workshop had a link of 'none', it would break on the workshops
page. This fixes that.