### PR TITLE
Add humans file with names of founders

### DIFF
--- a/_src/public/humans.txt
+++ b/_src/public/humans.txt
@@ -1,0 +1,10 @@
+Ivey Padgett
+Jonathan Warner
+Prince Wilson
+Eric Smithson
+Estella Gong
+Kevin Brown
+
+Website built and designed by Eric Colon
+Maintained by Jonathan Warner et al
+


### PR DESCRIPTION
I'm actually just testing the continous deployment for regressions, but
I've always wanted a humans.txt file.