### PR TITLE
Only display the last n events (configurable) and workshops

### DIFF
--- a/_data/config.yml
+++ b/_data/config.yml
@@ -9,6 +9,8 @@
     twitter: 'https://twitter.com/knighthacks'
     github: 'https://github.com/knighthacks'
     instagram: 'https://instagram.com/knighthacks/'
+  eventDisplayLimit: 4
+  workshopDisplayLimit: 4
   events:
     -
       name: 'Lightning Talk Social'

--- a/_src/index.html
+++ b/_src/index.html
@@ -62,13 +62,13 @@ resources:
         <div class="section__content">
           <ul class="card-list text-left">
             {% for event in site.events %}
-              {% if event.url && event.url !== 'none' %}
+              {% if event.url and event.url !== 'none' and loop.index0 < site.eventDisplayLimit %}
                 <li>
                   <a class="card" href="{{ event.url }}" target="_blank">
                     <span class="card__date">{{ event.date }}</span> {{ event.name }}
                   </a>
                 </li>
-              {% else %}
+              {% elif loop.index0 < site.eventDisplayLimit %}
                 <li class="card">
                   <span class="card__date">{{ event.date }}</span> {{ event.name }}
                 </li>
@@ -92,13 +92,13 @@ resources:
         <div class="section__content">
           <ul class="card-list text-left">
             {% for workshop in site.workshops %}
-              {% if workshop.url !== 'none' and loop.index0 < 4 %}
+              {% if workshop.url !== 'none' and loop.index0 < site.workshopDisplayLimit %}
                 <li>
                   <a class="card" href="{{ workshop.url }}">
                     <span class="card__date">{{ workshop.date }}</span> {{ workshop.name }}
                   </a>
                 </li>
-              {% elif loop.index0 < 4 %}
+              {% elif loop.index0 < site.workshopDisplayLimit %}
                 <li class="card">
                   <span class="card__date">{{ workshop.date }}</span> {{ workshop.name }}
                 </li>


### PR DESCRIPTION
I decided to extract the event and workshop display limits to the site's config.yml file. Now only the last 4 events are shown. This fixes #96.