### PR TITLE
Add `release` task for zero-downtime site updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ _src/assets/_bower_components
 
 # Output folders
 _dist
+_releases

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var del         = require('del'),
     path        = require('path'),
     swig        = require('swig'),
     yaml        = require('js-yaml'),
+    symlink     = require('gulp-symlink'),
     browserSync = require('browser-sync'),
     plugins     = require('gulp-load-plugins')({
       rename: { // Make sure these non-standard named gulp plugins load correctly
@@ -170,12 +171,26 @@ gulp.task('clear', function(done) {
 // Build task
 gulp.task('build', ['static', 'html', 'content', 'styles', 'scripts', 'fonts', 'images']);
 
+// Serve task
 gulp.task('serve', ['build', 'watch'], function() {
   browserSync.init({
     server: {
       baseDir: './_dist'
     }
   });
+});
+
+// Release task
+gulp.task('release', ['build'], function(done) {
+  var stamp = new Date().toISOString().replace(/[^\w]/g, '-');
+
+  return gulp.src('./_dist/**/*')
+    .pipe(gulp.dest('_releases/' + stamp))
+    .on('end', function () {
+      return gulp.src('_releases/' + stamp)
+        .pipe(symlink('_releases/current', { force: true }))
+        .on('end', done);
+    });
 });
 
 // Watch task

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gulp-sass": "^2.0.4",
     "gulp-shell": "^0.2.9",
     "gulp-size": "^1.1.0",
+    "gulp-symlink": "^2.1.3",
     "gulp-tap": "^0.1.3",
     "gulp-uglify": "^1.0.1",
     "gulp-uncss": "^0.5.0",


### PR DESCRIPTION
Probably resolves #83.

Now there is a `gulp release` task which builds releases into a `_releases` folder, symlinking the latest release to `_releases/current`. The server will have to be updated to use this instead of `_dist` for the site's root, and the commit hook handler will have to run `gulp release` instead of `gulp build`.