### PR TITLE
Prevent weird text wrapping on event/workshop cards

### DIFF
--- a/_src/assets/scss/elements/_cards.scss
+++ b/_src/assets/scss/elements/_cards.scss
@@ -1,7 +1,8 @@
 .card {
   position: relative;
 
-  display: block;
+  display: flex;
+  align-items: center;
   padding: $default-space;
 
   border: rem-calc(1) solid rgba(0,0,0,0.15);
@@ -39,6 +40,7 @@ a.card:hover {
 
     &__date {
       display: inline-block;
+      flex-shrink: 0;
       margin-right: $default-space / 2;
       padding: rem-calc(2) rem-calc(12);
       width: rem-calc(112);


### PR DESCRIPTION
I used flexbox to fix some of the strange text wrapping going on in the cards. This makes it a little less confusing when the title runs out of room.

### Before 
<img width="987" alt="screen shot 2015-11-21 at 9 51 53 am" src="https://cloud.githubusercontent.com/assets/1724000/11318986/c5b3f99e-9035-11e5-9218-65ac8732c9c8.png">

### After
<img width="987" alt="screen shot 2015-11-21 at 9 51 59 am" src="https://cloud.githubusercontent.com/assets/1724000/11318987/c5b4f5ec-9035-11e5-8cc0-0b0ec0fb3eae.png">
